### PR TITLE
remove C++17 features, fix bug in resizable array being static

### DIFF
--- a/src/cce_export.cc
+++ b/src/cce_export.cc
@@ -9,7 +9,10 @@
 
 namespace CCE_export {
 
-using std::vector, std::string, std::ostringstream, std::ios;
+using std::vector;
+using std::string;
+using std::ostringstream;
+using std::ios;
 
 void CCE_Export(CCTK_ARGUMENTS) {
   DECLARE_CCTK_ARGUMENTS;

--- a/src/cce_export.hh
+++ b/src/cce_export.hh
@@ -12,7 +12,8 @@
 
 namespace CCE_export {
 
-using std::vector, std::string;
+using std::vector;
+using std::string;
 
 extern "C" void CCE_Export(CCTK_ARGUMENTS);
 

--- a/src/h5_export.cc
+++ b/src/h5_export.cc
@@ -1,13 +1,5 @@
 #include "h5_export.hh"
 
-#if defined __cpp_lib_filesystem && __cpp_lib_filesystem < 201703L
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#include <filesystem>
-namespace fs = std::filesystem;
-#endif
-
 namespace CCE_export {
 
 using std::string;
@@ -172,11 +164,11 @@ void Output_Decomposed_Metric_Data(
   ostringstream basename;
   basename << base_file_name << "R" << setiosflags(ios::fixed) << setprecision(2)
            << rad << "." << extension;
-  string output_name = (fs::path(my_out_dir) / basename.str()).string();
+  string output_name = string(my_out_dir) + "/" + basename.str();
 
   hid_t file;
 
-  if (!fs::exists(output_name) ||
+  if (H5Fis_hdf5(output_name.c_str()) < 0 ||
       (!checked[output_name] && IO_TruncateOutputFiles(cctkGH))) {
     HDF5_ERROR(file =
 	       H5Fcreate(output_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT));

--- a/src/h5_export.cc
+++ b/src/h5_export.cc
@@ -10,7 +10,11 @@ namespace fs = std::filesystem;
 
 namespace CCE_export {
 
-using std::string, std::ostringstream, std::map, std::ios, std::setprecision;
+using std::string;
+using std::ostringstream;
+using std::map;
+using std::ios;
+using std::setprecision;
 
 #define HDF5_ERROR(fn_call)                                                    \
   do {                                                                         \

--- a/src/h5_export.hh
+++ b/src/h5_export.hh
@@ -18,7 +18,8 @@
 
 namespace CCE_export {
 
-using std::vector, std::string;
+using std::vector;
+using std::string;
 
 void Create_Dataset(string datasetname, CCTK_REAL *data, int mode_count);
 

--- a/src/interpolate.hh
+++ b/src/interpolate.hh
@@ -12,7 +12,8 @@
 
 namespace CCE_export {
 
-using std::vector, std::string;
+using std::vector;
+using std::string;
 
 void Interpolate_On_Sphere_With_Derivatives(
     CCTK_ARGUMENTS, vector<CCTK_REAL> &xs, vector<CCTK_REAL> &ys,

--- a/src/spherical_harmonic_decomposition.cc
+++ b/src/spherical_harmonic_decomposition.cc
@@ -2,7 +2,9 @@
 
 namespace CCE_export {
 
-using std::sin, std::cos, std::pow;
+using std::sin;
+using std::cos;
+using std::pow;
 
 // Copied from Multipole
 #define idx(xx, yy)                                                            \

--- a/src/spherical_harmonic_decomposition.cc
+++ b/src/spherical_harmonic_decomposition.cc
@@ -78,8 +78,10 @@ void Integrate(int array_size, int ntheta, int nphi, vector<CCTK_REAL> &array1r,
   CCTK_REAL dph = ph[iu] - ph[il];
 
   // Construct an array for the real integrand
-  static auto fr = std::make_unique<CCTK_REAL []>(array_size);
-  static auto fi = std::make_unique<CCTK_REAL []>(array_size);
+  static std::vector<CCTK_REAL> fr;
+  static std::vector<CCTK_REAL> fi;
+  fr.resize(array_size);
+  fi.resize(array_size);
 
   // the below calculations take the integral of conj(array1)*array2*sin(th)
   for (int i = 0; i < array_size; i++) {
@@ -92,8 +94,8 @@ void Integrate(int array_size, int ntheta, int nphi, vector<CCTK_REAL> &array1r,
         CCTK_WARN_ABORT,
         "The Simpson integration method requires even ntheta and even nphi");
   }
-  *outre = Simpson2DIntegral(fr.get(), ntheta, nphi, dth, dph);
-  *outim = Simpson2DIntegral(fi.get(), ntheta, nphi, dth, dph);
+  *outre = Simpson2DIntegral(fr.data(), ntheta, nphi, dth, dph);
+  *outim = Simpson2DIntegral(fi.data(), ntheta, nphi, dth, dph);
 }
 
 void Decompose_Spherical_Harmonics(


### PR DESCRIPTION
This fixes one (likely) bug namely setting up a `static` variable whose size is determined by a function argument (so could change for each function call).

Other changes remove dependency on `std::fileystem` (mostly b/c its presence is actually hard to check for) and some other C++17 code, so that, as a non-CarpetX code, it could be compiled with `-std=c++11`